### PR TITLE
Update mix.exs to expand deps and packages with parens

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -7,10 +7,10 @@ defmodule DatabaseUrl.Mixfile do
      elixir: "~> 1.0",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps,
+     deps: deps(),
      test_coverage: [tool: ExCoveralls],
      description: "Parse database URL and renturn keyword list for use with Ecto.",
-     package: package,
+     package: package(),
     ]
   end
 


### PR DESCRIPTION
Add parens to avoid issues like these for clients. These come up as warning as of elixir version 1.14 but will be an error for newer versions

warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  /Users/~/deps/database_url/mix.exs:10: DatabaseUrl.Mixfile.project/0

warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
  /Users/~/deps/database_url/mix.exs:13: DatabaseUrl.Mixfile.project/0